### PR TITLE
feature: Enhance DMG creation script for GlyphVisualizer with new features

### DIFF
--- a/.github/workflows/build-macOS-dmg.yml
+++ b/.github/workflows/build-macOS-dmg.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build MacOS DMG
     strategy:
       matrix:
-        os: [macos-14-large, macos-14-xlarge]
+        os: [macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Determine architecture

--- a/.github/workflows/build-macOS-dmg.yml
+++ b/.github/workflows/build-macOS-dmg.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build MacOS DMG
     strategy:
       matrix:
-        os: [macos-14, macos-14-large] # try macos-14-large in hope it is not part of the large runners not covered by gh pro sub
+        os: [macos-14, macos-15-intel]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Determine architecture

--- a/.github/workflows/build-macOS-dmg.yml
+++ b/.github/workflows/build-macOS-dmg.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build MacOS DMG
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-14, macos-14-large] # try macos-14-large in hope it is not part of the large runners not covered by gh pro sub
     runs-on: ${{ matrix.os }}
     steps:
       - name: Determine architecture

--- a/devscripts/make-dmg.sh
+++ b/devscripts/make-dmg.sh
@@ -48,6 +48,10 @@ mkdir -p "${BUILD_DIR}/GlyphVisualizer.app/Contents/Frameworks/"
 cd "${BUILD_DIR}"
 macdeployqt "${APP_NAME}"
 
+# macdeployqt copies Qt dylibs/frameworks that may not match the app signature; dyld then
+# terminates with CODESIGNING / Invalid Page. Deep ad-hoc sign unifies the bundle.
+codesign --force --deep --sign - "${APP_NAME}"
+
 # Rename the dmg file
 MACHINE_ARCH=$(uname -m)
 if [ "${MACHINE_ARCH}" = "x86_64" ]; then

--- a/devscripts/make-dmg.sh
+++ b/devscripts/make-dmg.sh
@@ -25,6 +25,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 PROJECT_DIR=${SCRIPT_DIR}/..
 CMAKE_SOURCE_DIR=${PROJECT_DIR}
 BUILD_DIR=${PROJECT_DIR}/build
+APP_NAME="GlyphVisualizer.app"
 
 cd "${CMAKE_SOURCE_DIR}"
 
@@ -44,8 +45,8 @@ mkdir -p "${BUILD_DIR}/GlyphVisualizer.app/Contents/Frameworks/"
 ## - libz is present in macOS
 
 # Package with macdeployqt
-cd "${BUILD_DIR}" # We need to change directory so the dmg volume name is correct
-macdeployqt "GlyphVisualizer.app" -dmg
+cd "${BUILD_DIR}"
+macdeployqt "${APP_NAME}"
 
 # Rename the dmg file
 MACHINE_ARCH=$(uname -m)
@@ -57,7 +58,115 @@ else
     echo "Unknown architecture: ${MACHINE_ARCH}"
 fi
 GV_DMG_NAME="GlyphVisualizer-${VERSION}_macOS-14-${MACHINE_ARCH}.dmg"
-mv "GlyphVisualizer.dmg" "${GV_DMG_NAME}"
+RW_DMG="${BUILD_DIR}/GlyphVisualizer-layout.dmg"
+STAGING_DIR="${BUILD_DIR}/GlyphVisualizer-dmg-staging"
+VOLUME_NAME="GlyphVisualizer"
+MOUNT_POINT="/Volumes/${VOLUME_NAME}"
+WINX=200
+WINY=120
+WINW=660
+WINH=400
+WIN_RIGHT=$((WINX + WINW))
+WIN_BOTTOM=$((WINY + WINH))
+ICON_SIZE=128
+TEXT_SIZE=16
+APP_X=180
+APP_Y=185
+APPLICATIONS_X=480
+APPLICATIONS_Y=185
+SKIP_FINDER_LAYOUT="${SKIP_FINDER_LAYOUT:-}"
+
+detach_dmg() {
+    local detach_target="$1"
+    local attempts=0
+    local max_attempts=3
+
+    until hdiutil detach "${detach_target}"; do
+        attempts=$((attempts + 1))
+        if [ "${attempts}" -ge "${max_attempts}" ]; then
+            echo "Detaching ${detach_target} with force."
+            hdiutil detach -force "${detach_target}" || {
+                echo "Failed to detach ${detach_target} after ${max_attempts} attempts."
+                return 1
+            }
+            return 0
+        fi
+        echo "Detach busy, retrying..."
+        sleep $((2 ** attempts))
+    done
+}
+
+if [ -f "${GV_DMG_NAME}" ]; then
+    rm -f "${GV_DMG_NAME}"
+fi
+
+if [ -f "${RW_DMG}" ]; then
+    rm -f "${RW_DMG}"
+fi
+
+rm -rf "${STAGING_DIR}"
+mkdir -p "${STAGING_DIR}"
+cp -R "${APP_NAME}" "${STAGING_DIR}/${APP_NAME}"
+ln -s /Applications "${STAGING_DIR}/Applications"
+
+hdiutil create \
+    -volname "${VOLUME_NAME}" \
+    -srcfolder "${STAGING_DIR}" \
+    -ov \
+    -format UDRW \
+    -fs HFS+ \
+    "${RW_DMG}"
+
+ATTACH_OUTPUT=$(hdiutil attach "${RW_DMG}" -mountpoint "${MOUNT_POINT}" -noautoopen)
+DEV_NAME=$(printf '%s\n' "${ATTACH_OUTPUT}" | sed -nE 's#^(/dev/disk[0-9]+).*#\1#p' | head -n 1)
+
+if [ -z "${DEV_NAME}" ]; then
+    echo "Failed to determine mounted DMG device name."
+    exit 1
+fi
+
+if [ ! -e "${MOUNT_POINT}/Applications" ]; then
+    ln -s /Applications "${MOUNT_POINT}/Applications"
+fi
+
+if [ "${SKIP_FINDER_LAYOUT}" != "1" ]; then
+    # Configure a polished drag-and-drop installer window in Finder.
+osascript <<EOF
+tell application "Finder"
+    tell disk "${VOLUME_NAME}"
+        open
+        set current view of container window to icon view
+        set toolbar visible of container window to false
+        set statusbar visible of container window to false
+        set bounds of container window to {${WINX}, ${WINY}, ${WIN_RIGHT}, ${WIN_BOTTOM}}
+        set theViewOptions to the icon view options of container window
+        set arrangement of theViewOptions to not arranged
+        set icon size of theViewOptions to ${ICON_SIZE}
+        set text size of theViewOptions to ${TEXT_SIZE}
+        set position of item "${APP_NAME}" of container window to {${APP_X}, ${APP_Y}}
+        set position of item "Applications" of container window to {${APPLICATIONS_X}, ${APPLICATIONS_Y}}
+        close
+        open
+        update without registering applications
+        delay 2
+    end tell
+end tell
+EOF
+else
+    echo "Skipping Finder layout customization."
+fi
+
+if [ "${MACHINE_ARCH}" = "arm64" ]; then
+    bless --folder "${MOUNT_POINT}" || true
+else
+    bless --folder "${MOUNT_POINT}" --openfolder "${MOUNT_POINT}" || true
+fi
+sync
+detach_dmg "${DEV_NAME}"
+
+hdiutil convert "${RW_DMG}" -format UDZO -imagekey zlib-level=9 -o "${GV_DMG_NAME}"
+rm -f "${RW_DMG}"
+rm -rf "${STAGING_DIR}"
 
 # Create checksum file
 echo ""


### PR DESCRIPTION
Improved macOS DMG packaging

- Introduced a new variable for the application name to improve maintainability.
- Updated the macdeployqt command to use the new APP_NAME variable.
- Added functionality to create a polished drag-and-drop installer window in Finder.
- Implemented a robust detaching mechanism for the DMG.
- Enhanced staging and cleanup processes for DMG creation.

<details>
<summary>New look:</summary>

<img width="667" height="580" alt="Screenshot 2026-04-14 at 21 31 25" src="https://github.com/user-attachments/assets/9d0e5639-f03b-4b37-969e-d1a98342e50f" />


</details>

<details>
<summary>------- Copilot Summary -------</summary>
This pull request significantly improves the macOS DMG packaging process in the `devscripts/make-dmg.sh` script. The main changes include replacing the simple `macdeployqt -dmg` call with a custom DMG creation workflow that creates a more user-friendly drag-and-drop installer, adds error handling, and provides options for Finder window customization.

**DMG packaging improvements:**

* Replaces the previous `macdeployqt -dmg` invocation with a custom script that creates a read-write DMG, stages the `.app` bundle and an `Applications` symlink, and then converts it to a compressed DMG for distribution. [[1]](diffhunk://#diff-e70c1cb4ed1fb6e091bff1c2a33e33dfaf3f71b752c054e47ec3886190d18570L47-R49) [[2]](diffhunk://#diff-e70c1cb4ed1fb6e091bff1c2a33e33dfaf3f71b752c054e47ec3886190d18570L60-R169)
* Adds logic to customize the Finder window layout using AppleScript, including window size, icon positions, and disabling toolbars/status bars, resulting in a polished drag-and-drop installer experience. This can be skipped by setting the `SKIP_FINDER_LAYOUT` environment variable.
* Implements a robust DMG detachment function (`detach_dmg`) with retries and forced detach as a fallback to handle busy disk images.

**Code quality and maintainability:**

* Introduces variables for frequently used values (e.g., `APP_NAME`, `RW_DMG`, `STAGING_DIR`, `VOLUME_NAME`) to improve readability and maintainability. [[1]](diffhunk://#diff-e70c1cb4ed1fb6e091bff1c2a33e33dfaf3f71b752c054e47ec3886190d18570R28) [[2]](diffhunk://#diff-e70c1cb4ed1fb6e091bff1c2a33e33dfaf3f71b752c054e47ec3886190d18570L60-R169)
* Adds cleanup steps to remove any previous DMG or staging directories before starting a new build, reducing the risk of packaging stale files.
</details>